### PR TITLE
Restrict endpoints to API connectors and add validation API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Creates new connector and endpoint definitions for the Analitiq DIP registry. Co
 - `connector-creator` builds `connector.json`, `manifest.json`, and repo scaffolding (CLAUDE.md, AGENTS.md, README.md, CHANGELOG.md)
 - `endpoint-creator` builds individual endpoint JSON files under `definition/endpoints/` and updates the manifest — **API connectors only** (database/other connectors do not have pre-defined endpoints)
 - `api-researcher` fetches auth details and endpoint schemas from official API docs (WebFetch → WebSearch → Playwright fallback)
-- If `ANALITIQ_API_KEY` is available, `start` validates all JSON against `https://rest.analitiq-dev.com/v1/validate/` and tags the repo as `validated` if compliant
+- If `ANALITIQ_API_KEY` is available, `start` validates all JSON against `https://rest.analitiq-dev.com/v1/validate/{connector|endpoint}` and adds the `validated` topic to the repo if compliant
 
 ### `analitiq-plugin-dataflow` (v2.0.0)
 Builds data integration pipelines using pre-defined connectors from the DIP registry (`analitiq-dip-registry` GitHub org). Does **not** create connectors — only downloads and wires them.
@@ -60,7 +60,7 @@ connector-{slug}/
 ├── CHANGELOG.md         # Version history
 └── definition/
     ├── connector.json   # Auth + connector config
-    └── manifest.json    # Connector manifest (empty endpoints)
+    └── manifest.json    # Connector manifest (empty endpoints array)
 ```
 
 ## Supported Auth Types

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,13 @@ This is the official directory of Analitiq Claude Code plugins for building data
 ### `analitiq-plugin-connector-builder` (v1.2.0)
 Creates new connector and endpoint definitions for the Analitiq DIP registry. Connectors are published to the `analitiq-dip-registry` GitHub org as individual repos named `connector-{slug}`.
 
-**Agent chain:** `start` (skill) → `connector-creator` → `endpoint-creator`, with `api-researcher` invoked automatically for API-type connectors.
+**Agent chain:** `start` (skill) → `connector-creator` → `endpoint-creator` (API only) → validate (optional), with `api-researcher` invoked automatically for API-type connectors.
 
-- `start` interviews the user, checks for duplicates in the registry, then dispatches agents
+- `start` interviews the user, checks for duplicates in the registry, collects optional `ANALITIQ_API_KEY`, then dispatches agents
 - `connector-creator` builds `connector.json`, `manifest.json`, and repo scaffolding (CLAUDE.md, AGENTS.md, README.md, CHANGELOG.md)
-- `endpoint-creator` builds individual endpoint JSON files under `definition/endpoints/` and updates the manifest
+- `endpoint-creator` builds individual endpoint JSON files under `definition/endpoints/` and updates the manifest — **API connectors only** (database/other connectors do not have pre-defined endpoints)
 - `api-researcher` fetches auth details and endpoint schemas from official API docs (WebFetch → WebSearch → Playwright fallback)
+- If `ANALITIQ_API_KEY` is available, `start` validates all JSON against `https://rest.analitiq-dev.com/v1/validate/` and tags the repo as `validated` if compliant
 
 ### `analitiq-plugin-dataflow` (v2.0.0)
 Builds data integration pipelines using pre-defined connectors from the DIP registry (`analitiq-dip-registry` GitHub org). Does **not** create connectors — only downloads and wires them.
@@ -30,13 +31,14 @@ Builds data integration pipelines using pre-defined connectors from the DIP regi
 ## Key Concepts
 
 - **Connector:** Auth config + metadata for a system (API, database, S3/SFTP). Lives in `connector-{slug}/definition/connector.json`.
-- **Endpoint:** Schema definition for a single API resource or DB table. Lives in `definition/endpoints/{name}.json`.
+- **Endpoint:** Schema definition for a single API resource. Lives in `definition/endpoints/{name}.json`. **API connectors only** — database/other connectors do not have pre-defined endpoints (their schema/table combinations are deployment-specific and discovered at runtime).
 - **Manifest:** Index of all endpoints for a connector. Lives in `definition/manifest.json`. Version is bumped automatically by GitHub Actions on PR merge via labels (`version:minor`, `version:patch`, `version:major`) — never bump manually.
 - **Connection:** Runtime auth credentials for a connector instance. Secrets go to `.secrets/{connection_id}.json`.
 - **Pipeline:** Full integration definition bundling connectors, connections, endpoints, streams, and mappings.
 
 ## Connector Directory Structure (output of connector-builder)
 
+**API connectors** (with endpoints):
 ```
 connector-{slug}/
 ├── CLAUDE.md            # Agent reference (auth, endpoints, caveats)
@@ -46,7 +48,19 @@ connector-{slug}/
 └── definition/
     ├── connector.json   # Auth + connector config
     ├── manifest.json    # Endpoint index
-    └── endpoints/       # Individual endpoint JSON files
+    └── endpoints/       # Individual endpoint JSON files (API only)
+```
+
+**Database and other connectors** (no endpoints):
+```
+connector-{slug}/
+├── CLAUDE.md            # Agent reference (auth, caveats)
+├── AGENTS.md            # Identical to CLAUDE.md, for non-Claude agents
+├── README.md            # Human docs
+├── CHANGELOG.md         # Version history
+└── definition/
+    ├── connector.json   # Auth + connector config
+    └── manifest.json    # Connector manifest (empty endpoints)
 ```
 
 ## Supported Auth Types

--- a/analitiq-plugin-connector-builder/agents/connector-creator.md
+++ b/analitiq-plugin-connector-builder/agents/connector-creator.md
@@ -163,10 +163,10 @@ The README must include these fixed sections (already in the template — do NOT
 And these connector-specific sections (fill in from research):
 - **Prerequisites** — what the user needs before connecting (API key, OAuth app, admin access, etc.)
 - **Authentication** — plain-language explanation of how to authenticate, including step-by-step credential instructions
-- **Available Endpoints** — table with Endpoint, Method, and Description columns
+- **Available Endpoints** (API connectors only) — table with Endpoint, Method, and Description columns. Omit for database/other connectors.
 - **Limitations** — rate limits, data freshness, sandbox vs production differences
 
-Update this file when new endpoints are added by the endpoint-creator.
+Update this file when new endpoints are added by the endpoint-creator (API connectors only).
 
 ## CHANGELOG.md — Version History
 
@@ -179,10 +179,10 @@ Track changes to the connector and its endpoints. Use this template:
 
 ### Added
 - Initial connector definition with {auth_type} authentication
-- Endpoints: {list of initial endpoints}
+- Endpoints: {list of initial endpoints} ← API connectors only; omit this line for database/other
 ```
 
-Update this file when endpoints are added or the connector is modified.
+Update this file when endpoints are added (API connectors only) or the connector is modified.
 
 ## Output
 
@@ -197,7 +197,7 @@ connector-{slug}/
 ├── CHANGELOG.md            # Version history
 └── definition/             # Connector definition files (machine-consumed JSON)
     ├── connector.json      # The connector definition with auth details
-    ├── manifest.json       # Endpoint manifest (initially empty endpoints array)
+    ├── manifest.json       # Endpoint index
     └── endpoints/          # Directory for endpoint definitions (API only)
 ```
 

--- a/analitiq-plugin-connector-builder/agents/connector-creator.md
+++ b/analitiq-plugin-connector-builder/agents/connector-creator.md
@@ -55,9 +55,9 @@ for new connectors: `https://github.com/analitiq-dip-registry/connector-template
 6. **Create the connector directory structure**:
    - Create directory `connector-{slug}/`
    - Create subdirectory `connector-{slug}/definition/`
-   - Create subdirectory `connector-{slug}/definition/endpoints/`
+   - **API connectors only**: Create subdirectory `connector-{slug}/definition/endpoints/`
    - Save `connector.json` in `definition/` (authentication and connector definition)
-   - Create `manifest.json` in `definition/` with the initial structure (no endpoints yet):
+   - Create `manifest.json` in `definition/` with the initial structure:
      ```json
      {
        "connector_id": "<connector_id>",
@@ -69,6 +69,11 @@ for new connectors: `https://github.com/analitiq-dip-registry/connector-template
      ```
      Version starts at `1.0.0`. Do NOT manually bump the version — a GitHub Action bumps it
      automatically when a PR is merged, based on PR labels (`version:minor`, `version:patch`, `version:major`).
+
+     > **Database and other connectors** do NOT have pre-defined endpoints. Their "endpoints" are
+     > schema/table combinations specific to each deployment and discovered at runtime. The manifest
+     > `endpoints` array stays empty, and no `endpoints/` directory is created.
+
    - Create `CLAUDE.md` in the repo root — agent reference for Claude Code (see CLAUDE.md section below)
    - Create `AGENTS.md` in the repo root — identical copy of CLAUDE.md for other agent frameworks
    - Create `README.md` in the repo root — human-readable documentation (see README.md section below)
@@ -120,13 +125,16 @@ type: {api|database|other}
 {Document any steps required after authentication, such as tenant/org selection, server URL
 discovery, etc. If none, state "None required."}
 
-## Available Endpoints
+## Available Endpoints (API connectors only)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | {path}   | {GET}  | {what it returns} |
 
-## Rate Limits
+> For database and other connectors, omit this section entirely. Their "endpoints" are schema/table
+> combinations specific to each deployment and are not pre-defined.
+
+## Rate Limits (API connectors only)
 
 - {max_requests} requests per {time_window_seconds} seconds
 
@@ -137,7 +145,7 @@ connector. For example: tenant-specific subdomains, non-standard pagination, req
 beyond auth, etc.}
 ```
 
-Update both CLAUDE.md and AGENTS.md when new endpoints are added by the endpoint-creator.
+Update both CLAUDE.md and AGENTS.md when new endpoints are added by the endpoint-creator (API connectors only).
 
 ## README.md — Human Documentation
 
@@ -179,6 +187,8 @@ Update this file when endpoints are added or the connector is modified.
 ## Output
 
 Create the full connector directory structure:
+
+**API connectors:**
 ```
 connector-{slug}/
 ├── CLAUDE.md               # Agent reference for Claude Code (auth, endpoints, caveats)
@@ -188,5 +198,17 @@ connector-{slug}/
 └── definition/             # Connector definition files (machine-consumed JSON)
     ├── connector.json      # The connector definition with auth details
     ├── manifest.json       # Endpoint manifest (initially empty endpoints array)
-    └── endpoints/          # Directory for endpoint definitions
+    └── endpoints/          # Directory for endpoint definitions (API only)
+```
+
+**Database and other connectors** (no `endpoints/` directory):
+```
+connector-{slug}/
+├── CLAUDE.md               # Agent reference for Claude Code (auth, caveats)
+├── AGENTS.md               # Agent reference for other frameworks (identical to CLAUDE.md)
+├── README.md               # Human documentation (setup instructions, credentials)
+├── CHANGELOG.md            # Version history
+└── definition/             # Connector definition files (machine-consumed JSON)
+    ├── connector.json      # The connector definition with auth details
+    └── manifest.json       # Connector manifest (empty endpoints array)
 ```

--- a/analitiq-plugin-connector-builder/agents/connector-creator.md
+++ b/analitiq-plugin-connector-builder/agents/connector-creator.md
@@ -4,7 +4,7 @@ color: orange
 description: >
   REQUIRED step for creating connector JSON. You MUST use this agent to create any connector
   definition — never create connector JSON directly. Creates the connector directory structure
-  with connector.json, manifest.json, and endpoints/ directory.
+  with connector.json, manifest.json, and (for API connectors) an endpoints/ directory.
 
   <example>
   user: "Create a connector for the Shopify API"

--- a/analitiq-plugin-connector-builder/agents/endpoint-creator.md
+++ b/analitiq-plugin-connector-builder/agents/endpoint-creator.md
@@ -2,9 +2,10 @@
 name: endpoint-creator
 color: cyan
 description: >
-  REQUIRED step for creating endpoint specifications. You MUST use this agent to create any
-  endpoint definition — never create endpoint JSON directly. For API endpoints, this agent
-  automatically invokes api-researcher to gather schema, filters, and pagination details.
+  REQUIRED step for creating API endpoint specifications. You MUST use this agent to create any
+  endpoint definition — never create endpoint JSON directly. This agent is ONLY for API connectors.
+  Database and other connectors do not have pre-defined endpoints.
+  Automatically invokes api-researcher to gather schema, filters, and pagination details.
   Saves endpoint JSON files under the connector's endpoints/ directory and updates manifest.json.
 
   <example>
@@ -17,8 +18,12 @@ skills:
   - endpoint-spec
 ---
 
-You are the Analitiq Endpoint Creator. You MUST be used to create any endpoint definition —
+You are the Analitiq Endpoint Creator. You MUST be used to create any API endpoint definition —
 endpoint JSON must never be assembled manually or by another agent.
+
+> **This agent is ONLY for API connectors.** Database and other connectors do not have pre-defined
+> endpoints — their "endpoints" are schema/table combinations specific to each deployment, discovered
+> at runtime. If dispatched for a non-API connector, stop and report this to the orchestrator.
 
 ## GitHub Registry
 
@@ -27,7 +32,8 @@ Connectors are named `connector-{slug}`.
 
 ## Workflow
 
-1. **Determine endpoint type** — API or database, based on the connector type.
+1. **Verify connector type** — this agent only handles API connectors. If the connector type is
+   `database` or `other`, stop immediately and report that endpoints are not applicable.
 
 2. **For API endpoints** — if the full endpoint details (response schema, filters, pagination) are
    not yet known, you MUST invoke the `api-researcher` agent to research the specific endpoint

--- a/analitiq-plugin-connector-builder/agents/endpoint-creator.md
+++ b/analitiq-plugin-connector-builder/agents/endpoint-creator.md
@@ -60,10 +60,10 @@ Save each endpoint as an individual JSON file under the connector's `definition/
 connector-{slug}/definition/endpoints/{endpoint_name}.json
 ```
 
-Use a descriptive filename derived from the endpoint path. For example:
+Use a descriptive filename derived from the API endpoint path. For example:
 - `/v1/transfers` → `transfers.json`
 - `/v1/accounts/balances` → `accounts-balances.json`
-- `public/users` → `public-users.json`
+- `/v2/customers/orders` → `customers-orders.json`
 
 ### 2. Update the manifest
 
@@ -90,8 +90,8 @@ in the `endpoints` array:
 
 Each entry in the manifest `endpoints` array should have:
 - `endpoint_id`: The endpoint's UUID
-- `endpoint`: The API path or table path
-- `method`: HTTP method or `DATABASE`
+- `endpoint`: The API path (e.g., `/v1/transfers`)
+- `method`: HTTP method (e.g., `GET`, `POST`)
 - `version`: Endpoint version number
 - `file`: Relative path to the endpoint JSON file
 

--- a/analitiq-plugin-connector-builder/skills/endpoint-spec/SKILL.md
+++ b/analitiq-plugin-connector-builder/skills/endpoint-spec/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: endpoint-spec
 description: >
-  Endpoint specification knowledge for creating API and database endpoint definitions.
+  Endpoint specification knowledge for creating API endpoint definitions.
   Contains the JSON Schema format, filter definitions, pagination types, and replication
   filter mapping used by the Analitiq platform. This skill should be loaded when creating
-  or modifying an endpoint definition (endpoints/*.json).
+  or modifying an API endpoint definition (endpoints/*.json). Database connectors do not
+  have pre-defined endpoints — their schemas are discovered at runtime.
 ---
 
 # Endpoint Specification
@@ -58,26 +59,6 @@ Read the full endpoint specification from `${CLAUDE_PLUGIN_ROOT}/skills/endpoint
   },
   "replication_filter_mapping": {
     "created_at": "since"
-  }
-}
-```
-
-## Quick Reference — Database Endpoint
-
-```json
-{
-  "connector_id": "uuid",
-  "endpoint_id": "uuid",
-  "endpoint": "public/table_name",
-  "method": "DATABASE",
-  "version": 1,
-  "endpoint_schema": {
-    "columns": [
-      { "name": "id", "type": "BIGINT", "nullable": false, "default": null, "autoincrement": false, "comment": null },
-      { "name": "name", "type": "VARCHAR(255)", "nullable": true, "default": null },
-      { "name": "_synced_at", "type": "TIMESTAMP", "nullable": true, "default": "now()" }
-    ],
-    "primary_keys": ["id"]
   }
 }
 ```

--- a/analitiq-plugin-connector-builder/skills/endpoint-spec/spec-api-endpoints.md
+++ b/analitiq-plugin-connector-builder/skills/endpoint-spec/spec-api-endpoints.md
@@ -1,6 +1,11 @@
 # API Connector Endpoints
 
-This document covers how connector endpoints are defined for API connectors (`connector_type: "api"`). For general connector structure see [spec-common-attributes.md](../connector-spec/spec-common-attributes.md). For database/file connector endpoints, use `method: "DATABASE"` and a column-based `endpoint_schema` — see the DB endpoint section below.
+This document covers how connector endpoints are defined for API connectors (`connector_type: "api"`). For general connector structure see [spec-common-attributes.md](../connector-spec/spec-common-attributes.md).
+
+> **The connector-builder plugin only creates endpoints for API connectors.** Database and other
+> connectors do not have pre-defined endpoints — their schema/table combinations are discovered
+> at runtime. A reference section for database endpoint format is included at the end for the
+> dataflow plugin's use.
 
 Each API connector has one or more **endpoints** — individual API paths that the pipeline runner can extract data from. Endpoints are saved as JSON files under the connector's `definition/endpoints/` directory.
 
@@ -237,7 +242,12 @@ Endpoint records are versioned. Only changes to `endpoint_schema` trigger a vers
 
 Version detection uses a SHA256 content hash (`_content_hash`) computed over the `endpoint_schema` field. The hash is canonicalized — dict keys are sorted and lists of dicts with a `name` key (e.g. columns) are sorted by name — so reordering fields does not trigger a false version bump.
 
-## DB Connector Endpoints
+## DB Connector Endpoints (Reference Only)
+
+> **Note:** The connector-builder plugin does NOT create database endpoints. Database connectors
+> do not have pre-defined endpoints — their schema/table combinations are deployment-specific and
+> discovered at runtime. This section is reference material for the dataflow plugin, which may
+> encounter database endpoint records when working with runtime-discovered schemas.
 
 Database connector endpoints (`method: "DATABASE"`) use the same table and API but with a different `endpoint_schema` structure:
 

--- a/analitiq-plugin-connector-builder/skills/start/SKILL.md
+++ b/analitiq-plugin-connector-builder/skills/start/SKILL.md
@@ -37,7 +37,8 @@ the right agents.
 2. Determine the connector type (API, database, other).
 3. **If API**: ask about specific endpoints the user wants to register and whether they have a documentation URL.
 4. **If database or other**: skip endpoint questions — these connectors do not have pre-defined endpoints.
-5. Summarize the requirements back to the user for confirmation.
+5. Check for `ANALITIQ_API_KEY` (see Validation section below) — env var first, then ask user.
+6. Summarize the requirements back to the user for confirmation.
 
 ## Requirements Output
 
@@ -112,8 +113,8 @@ documentation.
 ### Phase 3 — Validate (optional, requires ANALITIQ_API_KEY)
 
 If the user provided an `ANALITIQ_API_KEY` (see Validation section below), validate the created
-connector and endpoints against the Analitiq validation API. If all validations pass, tag the
-connector repo as "validated".
+connector and endpoints against the Analitiq validation API. If all validations pass, add the
+`validated` topic to the connector repo.
 
 ---
 
@@ -145,7 +146,7 @@ connector-{connector_name}/
 ├── CHANGELOG.md            # Version history
 └── definition/             # Connector definition files (machine-consumed JSON)
     ├── connector.json      # Authentication details and connector definition
-    └── manifest.json       # Connector manifest (no endpoints)
+    └── manifest.json       # Connector manifest (empty endpoints array)
 ```
 
 Database and other connectors do NOT have an `endpoints/` directory or endpoint JSON files.
@@ -205,8 +206,13 @@ curl -s -X POST "https://rest.analitiq-dev.com/v1/validate/endpoint" \
 
 **Responses:**
 - `200 {"valid": true}` — JSON is compliant
-- `422 {"valid": false, "errors": [...]}` — validation errors with field locations and messages
-- `400 {"valid": false, "message": "..."}` — bad request (malformed JSON, etc.)
+- `422` — validation errors (Pydantic format):
+  ```json
+  {"valid": false, "errors": [{"type": "missing", "loc": ["field_name"], "msg": "Field required"}]}
+  ```
+  Each error has `type` (error kind), `loc` (field path as array), and `msg` (human-readable message).
+  Use `loc` to find the field and `msg` to understand what to fix.
+- `400 {"valid": false, "message": "..."}` — bad request (malformed JSON, unknown schema type)
 
 ### Validation Workflow
 

--- a/analitiq-plugin-connector-builder/skills/start/SKILL.md
+++ b/analitiq-plugin-connector-builder/skills/start/SKILL.md
@@ -131,7 +131,7 @@ connector-{connector_name}/
 ├── CHANGELOG.md            # Version history
 └── definition/             # Connector definition files (machine-consumed JSON)
     ├── connector.json      # Authentication details and connector definition
-    ├── manifest.json       # Manifest listing all registered endpoints
+    ├── manifest.json       # Endpoint index
     └── endpoints/          # Directory containing all endpoint JSON definitions
         ├── {endpoint_name}.json
         └── ...

--- a/analitiq-plugin-connector-builder/skills/start/SKILL.md
+++ b/analitiq-plugin-connector-builder/skills/start/SKILL.md
@@ -3,8 +3,9 @@ name: start
 color: green
 description: >
   Entry point for building connectors and endpoints. Interviews the user to gather requirements
-  (system name, auth type, endpoints), checks the https://github.com/analitiq-dip-registry GitHub org for existing
-  connectors, then dispatches connector-creator and endpoint-creator agents.
+  (system name, auth type, endpoints for API connectors), checks the https://github.com/analitiq-dip-registry GitHub org
+  for existing connectors, then dispatches connector-creator and endpoint-creator (API only) agents.
+  Optionally validates output against the Analitiq validation API if ANALITIQ_API_KEY is available.
 argument-hint: "<system name and optional API docs URL>"
 model: inherit
 allowed-tools: Read, Glob, Grep, Bash, WebFetch, WebSearch, Agent
@@ -21,17 +22,21 @@ the right agents.
    - Is it an API or a Database?
    - If API: does the user have a link to the API documentation?
 
-2. **Endpoints to register** — what resources/tables to define:
-   - Which specific API endpoints or database tables?
+2. **Endpoints to register** — **API connectors only**:
+   - Which specific API endpoints? (e.g., `/v1/transfers`, `/v1/accounts`)
    - What fields are important?
    - Are there any filters (e.g., date ranges, status filters)?
+
+   > **Database and other connectors do NOT have pre-defined endpoints.** Their "endpoints" are
+   > schema/table combinations (e.g., `public/users`) that are specific to each deployment and
+   > discovered at runtime. Do NOT ask about endpoints for database or other connector types.
 
 ## Interview Flow
 
 1. Ask what system the user wants to create a connector for.
 2. Determine the connector type (API, database, other).
-3. Ask about specific endpoints the user wants to register.
-4. If an API is involved, ask if the user has a documentation URL — this helps the API Research Agent later.
+3. **If API**: ask about specific endpoints the user wants to register and whether they have a documentation URL.
+4. **If database or other**: skip endpoint questions — these connectors do not have pre-defined endpoints.
 5. Summarize the requirements back to the user for confirmation.
 
 ## Requirements Output
@@ -45,9 +50,9 @@ When requirements are confirmed, produce a structured summary:
 - System: {name}
 - Type: {api|database|other}
 - Connector slug: connector-{name}
-- Documentation URL: {url if provided}
+- Documentation URL: {url if provided, API only}
 
-### Endpoints
+### Endpoints (API connectors only)
 - {list of endpoints to register}
 ```
 
@@ -93,12 +98,22 @@ following agents. Do NOT create connector or endpoint JSON yourself.
 
 Dispatch: **`connector-creator`** — pass the system name, type, auth details, and documentation URL.
 
-### Phase 2 — Build endpoints (after connector is created)
+### Phase 2 — Build endpoints (API connectors only)
 
 **GATE: Do NOT proceed until the connector is created** — endpoints need the `connector_id`.
 
-Dispatch: **`endpoint-creator`** for each endpoint — pass the endpoint details and documentation URL.
-The endpoint-creator will use `api-researcher` if it needs API documentation.
+**Skip this phase entirely for database and other connector types.** These connectors do not have
+pre-defined endpoints — their endpoints are schema/table combinations discovered at runtime.
+
+For API connectors only, dispatch: **`endpoint-creator`** for each endpoint — pass the endpoint
+details and documentation URL. The endpoint-creator will use `api-researcher` if it needs API
+documentation.
+
+### Phase 3 — Validate (optional, requires ANALITIQ_API_KEY)
+
+If the user provided an `ANALITIQ_API_KEY` (see Validation section below), validate the created
+connector and endpoints against the Analitiq validation API. If all validations pass, tag the
+connector repo as "validated".
 
 ---
 
@@ -106,6 +121,7 @@ The endpoint-creator will use `api-researcher` if it needs API documentation.
 
 Each connector is stored in its own directory named `connector-{connector_name}/` with this structure:
 
+**API connectors** (with endpoints):
 ```
 connector-{connector_name}/
 ├── CLAUDE.md               # Agent reference for Claude Code (auth, endpoints, caveats)
@@ -120,13 +136,20 @@ connector-{connector_name}/
         └── ...
 ```
 
-- `CLAUDE.md` — agent reference for Claude Code: auth types, available endpoints, post-auth steps, caveats
-- `AGENTS.md` — identical to CLAUDE.md, for other agent frameworks
-- `README.md` — human-readable docs: prerequisites, how to get credentials, setup instructions
-- `CHANGELOG.md` — tracks additions and changes to the connector and endpoints
-- `definition/connector.json` — the connector definition with auth details
-- `definition/manifest.json` — a manifest file listing all endpoints registered for this connector
-- `definition/endpoints/` — directory containing individual endpoint JSON files
+**Database and other connectors** (no endpoints):
+```
+connector-{connector_name}/
+├── CLAUDE.md               # Agent reference for Claude Code (auth, caveats)
+├── AGENTS.md               # Agent reference for other frameworks (identical to CLAUDE.md)
+├── README.md               # Human documentation (setup instructions, credentials)
+├── CHANGELOG.md            # Version history
+└── definition/             # Connector definition files (machine-consumed JSON)
+    ├── connector.json      # Authentication details and connector definition
+    └── manifest.json       # Connector manifest (no endpoints)
+```
+
+Database and other connectors do NOT have an `endpoints/` directory or endpoint JSON files.
+Their "endpoints" (schema/table combinations) are specific to each deployment and discovered at runtime.
 
 ---
 
@@ -142,6 +165,73 @@ When creating a PR, apply the appropriate label:
 - `version:major` — breaking changes to connector auth or structure
 
 If no version label is applied, the version is not bumped.
+
+---
+
+## Validation — Optional but Recommended
+
+The Analitiq validation API validates connector and endpoint JSON against the authoritative Pydantic
+models to ensure 100% compliance. Without validation, agents may produce JSON with subtle errors.
+
+### Collecting the API Key
+
+1. Check if the environment variable `ANALITIQ_API_KEY` is set (run `echo $ANALITIQ_API_KEY`).
+2. If not set, ask the user: *"Do you have an Analitiq API key? You can get one for free at
+   analitiq-app.com. This lets us validate the connector against the official schema to ensure
+   it's 100% compliant. It's optional but recommended."*
+3. If the user provides a key, use it for validation. If they decline, skip validation and proceed
+   without it — but warn that the output may contain errors.
+
+### Validation API
+
+**Base URL:** `https://rest.analitiq-dev.com/v1`
+**Auth:** `x-api-key` header with the API key
+
+**Validate a connector:**
+```bash
+curl -s -X POST "https://rest.analitiq-dev.com/v1/validate/connector" \
+  -H "x-api-key: $ANALITIQ_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @connector-{slug}/definition/connector.json
+```
+
+**Validate an endpoint:**
+```bash
+curl -s -X POST "https://rest.analitiq-dev.com/v1/validate/endpoint" \
+  -H "x-api-key: $ANALITIQ_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @connector-{slug}/definition/endpoints/{endpoint_name}.json
+```
+
+**Responses:**
+- `200 {"valid": true}` — JSON is compliant
+- `422 {"valid": false, "errors": [...]}` — validation errors with field locations and messages
+- `400 {"valid": false, "message": "..."}` — bad request (malformed JSON, etc.)
+
+### Validation Workflow
+
+After Phase 1 (connector) and Phase 2 (endpoints, if API):
+
+1. **Validate the connector**: `POST /validate/connector` with `connector.json` body.
+   - If invalid: read the errors, fix the JSON, and re-validate until it passes.
+2. **Validate each endpoint** (API connectors only): `POST /validate/endpoint` with each endpoint JSON body.
+   - If invalid: read the errors, fix the JSON, and re-validate until it passes.
+3. **If ALL validations pass**: the connector is compliant. When creating or updating the
+   connector repo, add the topic `validated` to the GitHub repo:
+   ```bash
+   gh repo edit analitiq-dip-registry/connector-{slug} --add-topic validated
+   ```
+4. **If validation was skipped** (no API key): do NOT add the `validated` topic.
+
+### Updating Existing Connectors
+
+When updating an existing connector repo (adding endpoints, modifying connector.json):
+- Re-validate ALL connector and endpoint files, not just the changed ones.
+- If all pass, ensure the `validated` topic is present.
+- If any fail, remove the `validated` topic if it was previously set:
+  ```bash
+  gh repo edit analitiq-dip-registry/connector-{slug} --remove-topic validated
+  ```
 
 ---
 

--- a/analitiq-plugin-dataflow/agents/endpoint-data-mapper.md
+++ b/analitiq-plugin-dataflow/agents/endpoint-data-mapper.md
@@ -26,10 +26,14 @@ Do NOT run until ALL of the following exist:
 - Destination connector downloaded from the DIP registry
 - Source connection authenticated (by `connection-creator`)
 - Destination connection authenticated (by `connection-creator`)
-- Source endpoint available in the downloaded connector's `definition/endpoints/` directory
-- Destination endpoint available in the downloaded connector's `definition/endpoints/` directory
+- Source endpoint schema available — for API connectors this comes from pre-defined files in
+  `definition/endpoints/`; for database/other connectors the user must provide the schema
+  directly (these connectors do not have pre-defined endpoint files)
+- Destination endpoint schema available — same rule as source
 
-If any of these are missing, stop and report which components are not yet ready.
+If any of these are missing, stop and report which components are not yet ready. For database
+connectors without pre-defined endpoints, ask the user to provide the table schema (columns,
+types, primary keys) or connect to the database to introspect it.
 
 ## Mapping Specification
 

--- a/analitiq-plugin-dataflow/agents/registry-browser.md
+++ b/analitiq-plugin-dataflow/agents/registry-browser.md
@@ -86,8 +86,12 @@ ls analitiq-dip-registry/
 Once a connector is downloaded, report back:
 - Connector name and description
 - Auth type (from `AGENTS.md` or `definition/connector.json`)
-- Available endpoints (from `definition/endpoints/`)
+- Available endpoints (from `definition/endpoints/`, if the directory exists — API connectors only)
 - Any caveats or limitations
+
+> **Note:** Database and other connectors do not have a `definition/endpoints/` directory.
+> Their endpoints (schema/table combinations) are deployment-specific and discovered at runtime.
+> If the `endpoints/` directory does not exist, report that endpoints are not pre-defined.
 
 This information is used by the `start` agent to proceed with connection creation and pipeline assembly.
 


### PR DESCRIPTION
## Summary
- Endpoints are now only created for API connectors — database and other connectors discover their schema/table endpoints at runtime, so endpoint-creator is gated to API-only
- Added optional ANALITIQ_API_KEY validation flow to the start orchestrator: checks `$ANALITIQ_API_KEY` env var, falls back to interactive prompt, validates connector/endpoint JSON against `https://rest.analitiq-dev.com/v1/validate/`, and tags the GitHub repo with `validated` topic on success
- Updated directory structure docs to show both API (with endpoints/) and non-API (without) variants

## Test plan
- [ ] Verify `start` skill skips endpoint questions for database/other connector types
- [ ] Verify `endpoint-creator` rejects non-API connectors
- [ ] Verify `connector-creator` does not create `endpoints/` dir for database/other
- [ ] Verify validation flow works with a valid `ANALITIQ_API_KEY`
- [ ] Verify validation is gracefully skipped when no API key is provided
- [ ] Verify `validated` topic is added/removed correctly based on validation results

🤖 Generated with [Claude Code](https://claude.com/claude-code)