### PR TITLE
Add category_id assignment to connector-builder

### DIFF
--- a/analitiq-connector-builder/skills/connector-scaffolding/spec-common-attributes.md
+++ b/analitiq-connector-builder/skills/connector-scaffolding/spec-common-attributes.md
@@ -21,6 +21,7 @@ Every connector, regardless of type, has these root attributes:
 | `connector_name` | string | yes | Display name (e.g. "Xero", "PostgreSQL")                         |
 | `connector_type` | string | yes | One of: `api`, `database`, `other`                               |
 | `slug` | string | yes | URL-safe identifier (e.g. "xero", "postgresql"). GSI key         |
+| `category_id` | string | yes | UUID of the connector category (`connector_group_id` from the public [categories.json](https://raw.githubusercontent.com/analitiq-dip-registry/.github/main/categories.json)). Chosen in Phase 1.6 of `connector-wizard`. |
 | `form_fields` | array | no | Defines the credential or parameter fields the user must fill in |
 | `auth` | object | no | Authentication configuration (structure varies by type)          |
 | `connector_descr` | string | no | Human-readable description of the connector                      |

--- a/analitiq-connector-builder/skills/connector-spec-api/examples/api-key-connector.json
+++ b/analitiq-connector-builder/skills/connector-spec-api/examples/api-key-connector.json
@@ -3,6 +3,7 @@
   "connector_type": "api",
   "connector_descr": "HR performance management platform",
   "slug": "15five",
+  "category_id": "92d31a2c-54f4-4382-a0b0-4b3c3d05fa77",
   "base_url": "https://my.15five.com/api/public/",
   "client_required": false,
   "auth": {

--- a/analitiq-connector-builder/skills/connector-spec-db/examples/postgresql-connector.json
+++ b/analitiq-connector-builder/skills/connector-spec-db/examples/postgresql-connector.json
@@ -3,6 +3,7 @@
   "connector_type": "database",
   "connector_descr": "Open-source relational database",
   "slug": "postgresql",
+  "category_id": "3e5df540-1c3b-4d4a-bb53-d2d9a2b3df0a",
   "driver": "postgresql",
   "enable_ssh": true,
   "auth": {

--- a/analitiq-connector-builder/skills/connector-spec-storage/examples/s3-connector.json
+++ b/analitiq-connector-builder/skills/connector-spec-storage/examples/s3-connector.json
@@ -3,6 +3,7 @@
   "connector_type": "other",
   "connector_descr": "Amazon Simple Storage Service for object storage",
   "slug": "s3",
+  "category_id": "7123b91d-3f5e-4893-8b41-327c93a8c791",
   "auth": {
     "type": "credentials"
   },

--- a/analitiq-connector-builder/skills/connector-wizard/SKILL.md
+++ b/analitiq-connector-builder/skills/connector-wizard/SKILL.md
@@ -146,9 +146,19 @@ If the research results contain multiple auth methods in `auth_methods`:
 
 If only one auth method was returned, skip this phase entirely — no suffix needed, proceed directly.
 
+### Phase 1.6 — Category Selection
+
+Fetch `https://raw.githubusercontent.com/analitiq-dip-registry/.github/main/categories.json`,
+auto-suggest the best match based on the system and research results (e.g. Shopify →
+`e_commerce_platforms`), and confirm with the user. Record the chosen entry's
+`connector_group_id` — this is passed to Phase 2 as `category_id` and written to
+`connector.json`. If the fetch fails, ask the user whether to proceed without a category
+or abort.
+
 ### Phase 2 — Build connector
 
-Dispatch the matching type-specific connector creator agent with the research results as context:
+Dispatch the matching type-specific connector creator agent with the research results and
+the `category_id` from Phase 1.6 as context:
 
 - **API connectors**: dispatch **`api-connector-creator`** with the chosen auth method's data
 - **Database connectors**: dispatch **`db-connector-creator`**


### PR DESCRIPTION
## Summary
- Adds a new **Phase 1.6 — Category Selection** to `connector-wizard`: fetches the public [`categories.json`](https://raw.githubusercontent.com/analitiq-dip-registry/.github/main/categories.json), auto-suggests the best match, and confirms with the user.
- Passes the chosen `connector_group_id` to creator agents as `category_id`, written as a top-level field in `connector.json`.
- Documents `category_id` as a required common attribute in `spec-common-attributes.md` so all three creator agents (api/db/storage) treat it uniformly.
- Adds a realistic `category_id` UUID to one example per connector type for pattern matching.

## Test plan
- [ ] Run `connector-wizard` end-to-end for a new API connector (e.g. Shopify) and verify `category_id` is written to `connector.json`.
- [ ] Repeat for a database connector (PostgreSQL → `databases`) and a storage connector (S3 → `cloud_storage_platforms`).
- [ ] Verify wizard degrades gracefully when `categories.json` fetch fails (user prompt to proceed without category or abort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)