### PR TITLE
connector-builder: realign API endpoint authoring with published schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Builds data integration pipelines using pre-defined connectors from the DIP regi
 ## Key Concepts
 
 - **Connector:** Reusable provider transport + auth contract. Lives in `{alias}/definition/connector.json` and validates against `https://schemas.analitiq.ai/connector/latest.json`. Top-level fields: `$schema`, `kind` (one of `api`, `database`, `file`, `s3`, `stdout`), `alias`, `version`, `default_transport`, `transports`, `auth`, `connection_contract`, optional `resource_discovery` and `type_maps`. Server-managed fields (`connector_id`, `created_at`, `updated_at`) are stamped by the registry on insert and must NOT appear in authored documents.
-- **Endpoint:** Operation template for a single resource. API endpoints live in `{alias}/definition/endpoints/{endpoint-alias}.json` and validate against `https://schemas.analitiq.ai/api-endpoint/latest.json`. Database endpoints validate against `database-endpoint/latest.json` but are connection-scoped — the plugin does not author them; they are produced from the connector's `resource_discovery` workflow at runtime. Endpoint documents do not carry a `kind` field; the parent connector's `kind` selects the endpoint schema.
+- **Endpoint:** Operation template for a single resource. API endpoints live in `{alias}/definition/endpoints/{endpoint_id}.json` (filename matches the document's `endpoint_id`, pattern `^[a-z0-9][a-z0-9_-]*$`) and validate against `https://schemas.analitiq.ai/api-endpoint/latest.json`. Database endpoints validate against `database-endpoint/latest.json` but are connection-scoped — the plugin does not author them; they are produced from the connector's `resource_discovery` workflow at runtime. Endpoint documents do not carry a `kind` field; the parent connector's `kind` selects the endpoint schema.
 - **Type map:** Map from native types to Arrow canonical types. Authored as `connector.type_maps.native_to_arrow.rules` (an array of `{method, native, canonical}` entries with `method` ∈ `exact` | `regex`). For OLTP databases, the connector ships a comprehensive type map; for warehouses and document stores, restrict to documented native types. Connection-level supplements may extend coverage at runtime (e.g. PostGIS `GEOMETRY`).
 - **TLS declaration:** Database transports declare TLS via `transports.<name>.tls` with `mode` (refs `connection.parameters.ssl_mode`) and `ca_certificate` (refs `secrets.ssl_ca_certificate`). The runtime materializer translates this generic declaration into driver-specific arguments. The canonical SSL mode enum is `none | require | verify-ca | verify-full | prefer`.
 - **Value expression:** One of `ref` / `template` / `literal` / `function`. Refs and template variables target the closed scope list: `secrets.*`, `connection.parameters.*`, `connection.selections.*`, `connection.discovered.*`, `auth.*`, `runtime.*`, `stream.*`. Inline functions: `basic_auth`, `jwt_sign`, `url_encode`. Unknown scopes/functions are validation errors.
@@ -57,7 +57,7 @@ Version is bumped automatically by GitHub Actions on PR merge via labels (`versi
 └── definition/
     ├── connector.json              # validates against connector/latest.json
     └── endpoints/
-        └── {endpoint-alias}.json   # validates against api-endpoint/latest.json
+        └── {endpoint_id}.json      # filename = document.endpoint_id; validates against api-endpoint/latest.json
 ```
 
 **Database connectors** (no authored endpoints; `type_maps` and `tls` declared inside `connector.json`):

--- a/analitiq-connector-builder/CHANGELOG.md
+++ b/analitiq-connector-builder/CHANGELOG.md
@@ -3,6 +3,28 @@
 ## [unreleased]
 
 ### Changed
+- API endpoint authoring realigned with the published
+  `api-endpoint/latest.json` schema (engine PR #51):
+  - Endpoint documents now carry `endpoint_id` (pattern
+    `^[a-z0-9][a-z0-9_-]*$`); the previous top-level `alias` is
+    rejected. `endpoint-creator` agent, `io-contracts.md`
+    `EndpointCreatorOutput`, on-disk filename convention
+    (`endpoints/{endpoint_id}.json`), and the four api-endpoint test
+    fixtures updated accordingly.
+  - `operations.write` is now a mode-keyed map (`insert` / `upsert`
+    only); each mode block requires `request` + `input.schema` and
+    accepts optional `batching` (`{max_records ≥ 2}`), `params`,
+    `response`. `endpoint-creator` step 4 and `connector-spec-api`
+    SKILL cross-reference rewritten.
+  - `operations.read` guidance restated to match the published shape:
+    `request` and `response` required; `params`, `pagination`,
+    `replication` optional. Dropped the `from_param` wording — the
+    schema binds request shape directly via value expressions, with
+    `Param` objects declared under `params`.
+  - `scripts/validate_connector.py` type-map coverage walker now
+    descends into `operations.write.<mode>.input.schema` and
+    `operations.write.<mode>.params[*]` instead of treating `write`
+    as a single op.
 - `type_maps.native_to_arrow.rules[].canonical` values aligned with the
   fully-qualified Apache Arrow vocabulary used by the pipeline-builder's
   endpoint `arrow_type` contract. Renamed every `"canonical": "String"`

--- a/analitiq-connector-builder/CHANGELOG.md
+++ b/analitiq-connector-builder/CHANGELOG.md
@@ -24,7 +24,17 @@
   - `scripts/validate_connector.py` type-map coverage walker now
     descends into `operations.write.<mode>.input.schema` and
     `operations.write.<mode>.params[*]` instead of treating `write`
-    as a single op.
+    as a single op. Added three fixture trees + tests covering
+    fully-covered, uncovered, and multi-mode (insert + upsert)
+    write endpoints — including JSON-pointer assertions to guard
+    against the per-mode loop or `input.schema` path regressing.
+  - `endpoint-creator` write `response` bullet now describes
+    `affected_records` / `generated_keys` / `error.{code,message,details}`
+    / `metadata` / `success_when` instead of just saying "optional".
+  - Repo-root `CLAUDE.md` `Key Concepts` and `Connector Directory
+    Structure` sections updated from `{endpoint-alias}.json` to
+    `{endpoint_id}.json` so the project-level concept doc no longer
+    contradicts the plugin docs.
 - `type_maps.native_to_arrow.rules[].canonical` values aligned with the
   fully-qualified Apache Arrow vocabulary used by the pipeline-builder's
   endpoint `arrow_type` contract. Renamed every `"canonical": "String"`

--- a/analitiq-connector-builder/README.md
+++ b/analitiq-connector-builder/README.md
@@ -90,7 +90,7 @@ For each successfully built connector:
 ├── definition/
 │   ├── connector.json              # the connector body
 │   └── endpoints/                  # api connectors only
-│       └── {endpoint-alias}.json
+│       └── {endpoint_id}.json      # filename matches the document's endpoint_id
 └── README.md
 ```
 

--- a/analitiq-connector-builder/agents/endpoint-creator.md
+++ b/analitiq-connector-builder/agents/endpoint-creator.md
@@ -30,7 +30,8 @@ containing one endpoint document body.
    `^[a-z0-9][a-z0-9_-]*$`. This is the endpoint document's stable
    identifier; the schema does not accept `alias` on endpoints.
 3. Author `operations.read` when the resource is readable. Required keys
-   are `request` and `response`; `params`, `pagination`, `replication`
+   are `request` and `response` (and inside `response`, both `records`
+   and `schema` are required); `params`, `pagination`, `replication`
    are optional.
    - `request.method` (`GET` or `POST`) and `request.path`.
    - `request.transport_ref` — only if not the default transport.
@@ -58,7 +59,17 @@ containing one endpoint document body.
    - `batching` (optional) — `{"max_records": <int ≥ 2>}` when the
      provider documents a per-request cap.
    - `params` (optional) — same shape as read params.
-   - `response` (optional).
+   - `response` (optional) — write-result extraction. All keys
+     optional; populate whichever the provider documents:
+     - `affected_records` — value expression resolving to the count of
+       impacted records.
+     - `generated_keys` — value expression resolving to
+       provider-assigned identifiers.
+     - `error` — `{code, message, details}`, each a value expression,
+       for failure parsing.
+     - `metadata` — named value expressions for response metadata.
+     - `success_when` — predicate (`eq` / `neq` / `exists` / `and` /
+       `or` / …) determining operation success.
 5. At least one of `operations.read` or `operations.write` must be
    present. Omit the other when the resource is read-only or
    write-only.

--- a/analitiq-connector-builder/agents/endpoint-creator.md
+++ b/analitiq-connector-builder/agents/endpoint-creator.md
@@ -26,20 +26,42 @@ containing one endpoint document body.
 ## Process
 
 1. Set `$schema` to `https://schemas.analitiq.ai/api-endpoint/latest.json`.
-2. Set `alias` from the resource descriptor (lowercase, hyphen/underscore).
-3. Author `operations.read` (and `operations.write` when applicable):
-   - `request.method` and `request.path`.
+2. Set `endpoint_id` from the resource descriptor — pattern
+   `^[a-z0-9][a-z0-9_-]*$`. This is the endpoint document's stable
+   identifier; the schema does not accept `alias` on endpoints.
+3. Author `operations.read` when the resource is readable. Required keys
+   are `request` and `response`; `params`, `pagination`, `replication`
+   are optional.
+   - `request.method` (`GET` or `POST`) and `request.path`.
    - `request.transport_ref` — only if not the default transport.
-   - `params` — declared operation inputs with `in` (query / header / path
-     / body), `type`, `required`, `default` (often a `ref` into
-     `connection.selections.*`), `operators` for filterable params.
-   - `request.query` / `request.headers` / `request.body` bind to params
-     via `from_param`.
+   - `request.query` / `request.headers` / `request.path_params` /
+     `request.body` — declarative request shape. Values are
+     value expressions (e.g. `{"ref": "connection.parameters.foo"}`).
+   - `params` — declared operation inputs, each a `Param` with `in`
+     (`query` / `header` / `path` / `body`), `type`, `required`,
+     optional `default` (value expression), `operators` for filterable
+     params, and `controlled_by` when pagination / replication owns it.
    - `pagination` — populate per the connector's pagination style.
    - `replication` — only if the resource supports incremental sync.
    - `response.records` — `ref` whose path starts with `response.body`,
      selecting the iterable record collection.
    - `response.schema` — JSON Schema describing the response body.
+4. Author `operations.write` when the resource is writable. `write` is a
+   **mode-keyed map**; the schema accepts only `insert` and `upsert` as
+   keys, and at least one mode is required when `write` is present.
+   Each mode block holds:
+   - `request` (required) — `method` (`POST` / `PUT` / `PATCH`), `path`,
+     and the same optional `query` / `headers` / `path_params` / `body`
+     / `transport_ref` keys as the read request.
+   - `input` (required) — `{"schema": <JsonSchemaPropertyNode>}`
+     describing one provider-facing destination record.
+   - `batching` (optional) — `{"max_records": <int ≥ 2>}` when the
+     provider documents a per-request cap.
+   - `params` (optional) — same shape as read params.
+   - `response` (optional).
+5. At least one of `operations.read` or `operations.write` must be
+   present. Omit the other when the resource is read-only or
+   write-only.
 
 ## Hard rules
 

--- a/analitiq-connector-builder/agents/endpoint-creator.md
+++ b/analitiq-connector-builder/agents/endpoint-creator.md
@@ -68,8 +68,9 @@ containing one endpoint document body.
      - `error` — `{code, message, details}`, each a value expression,
        for failure parsing.
      - `metadata` — named value expressions for response metadata.
-     - `success_when` — predicate (`eq` / `neq` / `exists` / `and` /
-       `or` / …) determining operation success.
+     - `success_when` — predicate determining operation success.
+       Schema-closed set: `eq`, `neq`, `lt`, `lte`, `gt`, `gte`,
+       `exists`, `missing`, `empty`, `not_empty`, `and`, `or`, `not`.
 5. At least one of `operations.read` or `operations.write` must be
    present. Omit the other when the resource is read-only or
    write-only.

--- a/analitiq-connector-builder/scripts/validate_connector.py
+++ b/analitiq-connector-builder/scripts/validate_connector.py
@@ -1027,6 +1027,10 @@ def _collect_endpoint_natives(endpoint_doc: dict) -> list[tuple[str, str]]:
 
     write = operations.get("write")
     if isinstance(write, dict):
+        # Per api-endpoint/latest.json, write mode keys are restricted to
+        # {"insert", "upsert"}; Layer 1 rejects others. We iterate whatever
+        # is present so a future schema-side mode addition is picked up
+        # without code change.
         for mode, mode_op in write.items():
             if not isinstance(mode_op, dict):
                 continue

--- a/analitiq-connector-builder/scripts/validate_connector.py
+++ b/analitiq-connector-builder/scripts/validate_connector.py
@@ -1011,35 +1011,55 @@ def _collect_endpoint_natives(endpoint_doc: dict) -> list[tuple[str, str]]:
     """Walk an api-endpoint document and yield (native_string, json_pointer).
 
     Sources:
-    - operations.read.response.schema (JSON Schema, recursive into properties / items / *Of branches)
-    - operations.read.params[*] and operations.write.params[*]
+    - operations.read.response.schema and operations.read.params[*]
+    - operations.write.<mode>.input.schema and operations.write.<mode>.params[*]
+      where <mode> is `insert` or `upsert` (write is mode-keyed per the
+      published api-endpoint schema).
     """
     out: list[tuple[str, str]] = []
     operations = endpoint_doc.get("operations") or {}
     if not isinstance(operations, dict):
         return out
-    for op_name in ("read", "write"):
-        op = operations.get(op_name)
-        if not isinstance(op, dict):
-            continue
-        # response.schema (read only — write usually has no records-style response)
-        response = op.get("response")
-        if isinstance(response, dict):
-            schema = response.get("schema")
-            if isinstance(schema, dict):
-                _collect_natives_from_jsonschema(
-                    schema, f"/operations/{op_name}/response/schema", out
-                )
-        # params
-        params = op.get("params")
-        if isinstance(params, dict):
-            for pname, pspec in params.items():
-                if not isinstance(pspec, dict):
-                    continue
-                native = _native_from_type_format(pspec.get("type"), pspec.get("format"))
-                if native:
-                    out.append((native, f"/operations/{op_name}/params/{pname}"))
+
+    read = operations.get("read")
+    if isinstance(read, dict):
+        _collect_op_natives(read, "/operations/read", schema_field="response", out=out)
+
+    write = operations.get("write")
+    if isinstance(write, dict):
+        for mode, mode_op in write.items():
+            if not isinstance(mode_op, dict):
+                continue
+            _collect_op_natives(
+                mode_op, f"/operations/write/{mode}", schema_field="input", out=out
+            )
     return out
+
+
+def _collect_op_natives(
+    op: dict, base_pointer: str, *, schema_field: str, out: list[tuple[str, str]]
+) -> None:
+    """Collect natives from one operation block (read or one write mode).
+
+    `schema_field` is `response` for read (records + schema) or `input`
+    for write modes (schema). The schema sub-document is walked as JSON
+    Schema; params are scanned as flat type/format pairs.
+    """
+    body = op.get(schema_field)
+    if isinstance(body, dict):
+        schema = body.get("schema")
+        if isinstance(schema, dict):
+            _collect_natives_from_jsonschema(
+                schema, f"{base_pointer}/{schema_field}/schema", out
+            )
+    params = op.get("params")
+    if isinstance(params, dict):
+        for pname, pspec in params.items():
+            if not isinstance(pspec, dict):
+                continue
+            native = _native_from_type_format(pspec.get("type"), pspec.get("format"))
+            if native:
+                out.append((native, f"{base_pointer}/params/{pname}"))
 
 
 def _native_from_type_format(t: Any, f: Any) -> str | None:

--- a/analitiq-connector-builder/scripts/validate_connector.py
+++ b/analitiq-connector-builder/scripts/validate_connector.py
@@ -1027,10 +1027,9 @@ def _collect_endpoint_natives(endpoint_doc: dict) -> list[tuple[str, str]]:
 
     write = operations.get("write")
     if isinstance(write, dict):
-        # Per api-endpoint/latest.json, write mode keys are restricted to
-        # {"insert", "upsert"}; Layer 1 rejects others. We iterate whatever
-        # is present so a future schema-side mode addition is picked up
-        # without code change.
+        # Layer 1 (api-endpoint/latest.json) already rejects modes outside
+        # {"insert", "upsert"}; iterating defensively keeps this walker
+        # correct if the schema later widens the enum.
         for mode, mode_op in write.items():
             if not isinstance(mode_op, dict):
                 continue

--- a/analitiq-connector-builder/skills/connector-builder/SKILL.md
+++ b/analitiq-connector-builder/skills/connector-builder/SKILL.md
@@ -94,7 +94,7 @@ sub-agents own those skills.
    ├── definition/
    │   ├── connector.json
    │   └── endpoints/
-   │       └── {endpoint-alias}.json   # api connectors only — one file per endpoint
+   │       └── {endpoint_id}.json      # api connectors only — one file per endpoint; filename = document.endpoint_id
    └── README.md
    ```
 

--- a/analitiq-connector-builder/skills/connector-builder/references/io-contracts.md
+++ b/analitiq-connector-builder/skills/connector-builder/references/io-contracts.md
@@ -233,12 +233,16 @@ Returned by `api-connector-creator` and `db-connector-creator`.
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["alias", "document"],
+        "required": ["endpoint_id", "document"],
         "properties": {
-          "alias": { "type": "string" },
+          "endpoint_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9_-]*$",
+            "description": "Stable endpoint identifier; mirrors document.endpoint_id and is used by the orchestrator to derive the on-disk filename."
+          },
           "document": {
             "type": "object",
-            "description": "One endpoint document body. Must validate against https://schemas.analitiq.ai/api-endpoint/latest.json."
+            "description": "One endpoint document body. Must validate against https://schemas.analitiq.ai/api-endpoint/latest.json and carry the same endpoint_id at its top level."
           }
         }
       }

--- a/analitiq-connector-builder/skills/connector-builder/references/pipeline.md
+++ b/analitiq-connector-builder/skills/connector-builder/references/pipeline.md
@@ -120,7 +120,7 @@ predictable paths:
 ├── definition/
 │   ├── connector.json
 │   └── endpoints/
-│       └── {endpoint-alias}.json   # api connectors only — one file per endpoint
+│       └── {endpoint_id}.json      # api connectors only — one file per endpoint; filename = document.endpoint_id
 └── README.md
 ```
 

--- a/analitiq-connector-builder/skills/connector-spec-api/SKILL.md
+++ b/analitiq-connector-builder/skills/connector-spec-api/SKILL.md
@@ -35,6 +35,21 @@ Pick what you need for the auth and pagination styles you're authoring:
 - Pagination styles (offset / cursor / page / link).
 - Replication for incremental sync.
 
+## Endpoint `operations` shape (cross-reference)
+
+Endpoint authoring lives in the `endpoint-creator` agent, but the
+operations vocabulary it consumes is API-specific and worth pinning here:
+
+- `operations.read` is a single object with required `request` + `response`
+  and optional `params` / `pagination` / `replication`.
+- `operations.write` is a **mode-keyed map** — keys are restricted to
+  `insert` and `upsert`. Each mode block holds required `request` +
+  `input` (`{"schema": <JsonSchemaPropertyNode>}` for one destination
+  record) and optional `batching` (`{"max_records": <int ≥ 2>}`),
+  `params`, `response`.
+- At least one of `read` / `write` must be present; omit the other when
+  the resource is one-directional.
+
 ## What this skill does NOT cover
 
 - DSN URL templates, bindings, or encoding enums (that's `connector-spec-db`).

--- a/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_combiners/endpoints/events.json
+++ b/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_combiners/endpoints/events.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.analitiq.ai/api-endpoint/latest.json",
-  "alias": "events",
+  "endpoint_id": "events",
   "operations": {
     "read": {
       "request": { "method": "GET", "path": "/events" },

--- a/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_covered/endpoints/orders.json
+++ b/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_covered/endpoints/orders.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.analitiq.ai/api-endpoint/latest.json",
-  "alias": "orders",
+  "endpoint_id": "orders",
   "operations": {
     "read": {
       "request": { "method": "GET", "path": "/orders" },

--- a/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_covered/endpoints/users.json
+++ b/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_covered/endpoints/users.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.analitiq.ai/api-endpoint/latest.json",
-  "alias": "users",
+  "endpoint_id": "users",
   "operations": {
     "read": {
       "request": { "method": "GET", "path": "/users" },

--- a/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_uncovered/endpoints/users.json
+++ b/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_uncovered/endpoints/users.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.analitiq.ai/api-endpoint/latest.json",
-  "alias": "users",
+  "endpoint_id": "users",
   "operations": {
     "read": {
       "request": { "method": "GET", "path": "/users" },

--- a/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_covered/connector.json
+++ b/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_covered/connector.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://schemas.analitiq.ai/connector/latest.json",
+  "kind": "api",
+  "alias": "fixture-write-covered",
+  "version": "1.0.0",
+  "default_transport": "api",
+  "transports": {
+    "api": {
+      "transport_type": "http",
+      "base_url": "https://api.example.com",
+      "headers": {
+        "Authorization": { "template": "Bearer ${secrets.api_key}" }
+      }
+    }
+  },
+  "auth": { "type": "api_key" },
+  "connection_contract": {
+    "inputs": {
+      "api_key": {
+        "source": "user", "phase": "auth", "storage": "secrets",
+        "type": "string", "required": true, "secret": true
+      }
+    }
+  },
+  "type_maps": {
+    "native_to_arrow": {
+      "rules": [
+        { "method": "exact", "native": "uuid",      "canonical": "Utf8" },
+        { "method": "exact", "native": "date-time", "canonical": "Timestamp(MICROSECOND, UTC)" },
+        { "method": "exact", "native": "string",    "canonical": "Utf8" },
+        { "method": "exact", "native": "integer",   "canonical": "Int64" },
+        { "method": "exact", "native": "boolean",   "canonical": "Boolean" }
+      ]
+    }
+  }
+}

--- a/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_covered/endpoints/contacts.json
+++ b/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_covered/endpoints/contacts.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schemas.analitiq.ai/api-endpoint/latest.json",
+  "endpoint_id": "contacts",
+  "operations": {
+    "write": {
+      "insert": {
+        "request": { "method": "POST", "path": "/contacts" },
+        "input": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "id":         { "type": "string", "format": "uuid" },
+              "name":       { "type": "string" },
+              "created_at": { "type": "string", "format": "date-time" }
+            }
+          }
+        },
+        "batching": { "max_records": 100 },
+        "params": {
+          "tenant_id": { "in": "query", "type": "string", "format": "uuid", "required": true }
+        }
+      }
+    }
+  }
+}

--- a/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_multimode/connector.json
+++ b/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_multimode/connector.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schemas.analitiq.ai/connector/latest.json",
+  "kind": "api",
+  "alias": "fixture-write-multimode",
+  "version": "1.0.0",
+  "default_transport": "api",
+  "transports": {
+    "api": {
+      "transport_type": "http",
+      "base_url": "https://api.example.com",
+      "headers": {
+        "Authorization": { "template": "Bearer ${secrets.api_key}" }
+      }
+    }
+  },
+  "auth": { "type": "api_key" },
+  "connection_contract": {
+    "inputs": {
+      "api_key": {
+        "source": "user", "phase": "auth", "storage": "secrets",
+        "type": "string", "required": true, "secret": true
+      }
+    }
+  },
+  "type_maps": {
+    "native_to_arrow": {
+      "rules": [
+        { "method": "exact", "native": "string", "canonical": "Utf8" }
+      ]
+    }
+  }
+}

--- a/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_multimode/endpoints/contacts.json
+++ b/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_multimode/endpoints/contacts.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schemas.analitiq.ai/api-endpoint/latest.json",
+  "endpoint_id": "contacts",
+  "operations": {
+    "write": {
+      "insert": {
+        "request": { "method": "POST", "path": "/contacts" },
+        "input": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "format": "uuid" }
+            }
+          }
+        }
+      },
+      "upsert": {
+        "request": { "method": "PUT", "path": "/contacts" },
+        "input": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "updated_at": { "type": "string", "format": "date-time" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_uncovered/connector.json
+++ b/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_uncovered/connector.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schemas.analitiq.ai/connector/latest.json",
+  "kind": "api",
+  "alias": "fixture-write-uncovered",
+  "version": "1.0.0",
+  "default_transport": "api",
+  "transports": {
+    "api": {
+      "transport_type": "http",
+      "base_url": "https://api.example.com",
+      "headers": {
+        "Authorization": { "template": "Bearer ${secrets.api_key}" }
+      }
+    }
+  },
+  "auth": { "type": "api_key" },
+  "connection_contract": {
+    "inputs": {
+      "api_key": {
+        "source": "user", "phase": "auth", "storage": "secrets",
+        "type": "string", "required": true, "secret": true
+      }
+    }
+  },
+  "type_maps": {
+    "native_to_arrow": {
+      "rules": [
+        { "method": "exact", "native": "string",  "canonical": "Utf8" },
+        { "method": "exact", "native": "integer", "canonical": "Int64" }
+      ]
+    }
+  }
+}

--- a/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_uncovered/endpoints/contacts.json
+++ b/analitiq-connector-builder/tests/connector_validator/fixtures/api_endpoints_write_uncovered/endpoints/contacts.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schemas.analitiq.ai/api-endpoint/latest.json",
+  "endpoint_id": "contacts",
+  "operations": {
+    "write": {
+      "insert": {
+        "request": { "method": "POST", "path": "/contacts" },
+        "input": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "id":         { "type": "string", "format": "uuid" },
+              "created_at": { "type": "string", "format": "date-time" }
+            }
+          }
+        },
+        "params": {
+          "dry_run": { "in": "query", "type": "boolean", "required": false }
+        }
+      }
+    }
+  }
+}

--- a/analitiq-connector-builder/tests/connector_validator/test_validator.py
+++ b/analitiq-connector-builder/tests/connector_validator/test_validator.py
@@ -292,6 +292,54 @@ def test_api_endpoint_coverage_flags_uncovered_natives():
     assert "'date-time'" in messages, f"expected uncovered 'date-time' to be flagged; got {errs}"
 
 
+def test_api_endpoint_write_coverage_passes_when_input_and_params_covered():
+    """API connector with write-side input.schema + params natives fully covered by type_maps."""
+    result = run_validator(
+        FIXTURES / "api_endpoints_write_covered" / "connector.json",
+        "--semantic-only",
+    )
+    errs = errors_of(result, "type-map-coverage")
+    assert not errs, f"expected no coverage errors when write fully covered; got {errs}"
+
+
+def test_api_endpoint_write_coverage_flags_uncovered_input_and_params():
+    """Write-side natives in operations.write.<mode>.input.schema and .params must be walked."""
+    result = run_validator(
+        FIXTURES / "api_endpoints_write_uncovered" / "connector.json",
+        "--semantic-only",
+    )
+    errs = errors_of(result, "type-map-coverage")
+    messages = " ".join(e["message"] for e in errs)
+    assert "'uuid'" in messages, f"expected uncovered write input 'uuid' to be flagged; got {errs}"
+    assert "'date-time'" in messages, f"expected uncovered write input 'date-time' to be flagged; got {errs}"
+    assert "'boolean'" in messages, f"expected uncovered write param 'boolean' to be flagged; got {errs}"
+    # JSON pointers must locate the natives under the mode-keyed write path,
+    # not at the bare operations/write level — guards against the walker
+    # dropping the <mode> layer.
+    assert "/operations/write/insert/input/schema" in messages, \
+        f"expected /operations/write/insert/input/schema in pointers; got {messages}"
+    assert "/operations/write/insert/params/" in messages, \
+        f"expected /operations/write/insert/params/ in pointers; got {messages}"
+
+
+def test_api_endpoint_write_coverage_walks_all_modes():
+    """Both insert and upsert modes must be walked — guards the per-mode loop."""
+    result = run_validator(
+        FIXTURES / "api_endpoints_write_multimode" / "connector.json",
+        "--semantic-only",
+    )
+    errs = errors_of(result, "type-map-coverage")
+    messages = " ".join(e["message"] for e in errs)
+    # insert.input.schema declares uuid; upsert.input.schema declares date-time.
+    # A regression that hardcoded only one mode would fail one of these.
+    assert "'uuid'" in messages, f"expected insert-mode 'uuid' to be flagged; got {errs}"
+    assert "'date-time'" in messages, f"expected upsert-mode 'date-time' to be flagged; got {errs}"
+    assert "/operations/write/insert/input/schema" in messages, \
+        f"expected insert pointer; got {messages}"
+    assert "/operations/write/upsert/input/schema" in messages, \
+        f"expected upsert pointer; got {messages}"
+
+
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Engine PR [analitiq-engine#51](https://github.com/analitiq-ai/analitiq-engine/pull/51) renamed the endpoint identifier to `endpoint_id` and restructured `operations.write` into a mode-keyed map (`insert` / `upsert`). The published `api-endpoint/latest.json` schema already enforces both. This PR brings the `analitiq-connector-builder` plugin's authoring guidance, validator, and fixtures into alignment.

### Authoring changes
- `endpoint-creator` agent: writes `endpoint_id` (pattern `^[a-z0-9][a-z0-9_-]*$`), not `alias`.
- `operations.write` is now mode-keyed (`insert` / `upsert`); each mode block requires `request` + `input.schema` and accepts optional `batching` (`{max_records ≥ 2}`), `params`, `response`.
- `operations.read` guidance restated: `request` and `response` required; `params`, `pagination`, `replication` optional. Dropped the obsolete `from_param` wording — request shape now binds via value expressions, with `Param` objects declared under `params`.
- `connector-spec-api/SKILL.md`: added a cross-reference section pinning the `operations` shape.

### Plumbing
- `EndpointCreatorOutput` (`io-contracts.md`) now requires `endpoint_id` instead of `alias`.
- On-disk filename convention updated to `endpoints/{endpoint_id}.json` across SKILL, references/pipeline.md, and README.
- `scripts/validate_connector.py` — `_collect_endpoint_natives` rewritten to fan out across `operations.write.<mode>.params` and `operations.write.<mode>.input.schema` (was treating `write` as a single op, which silently skipped destination-record native types post-restructure).

### Fixtures
- Renamed `alias` → `endpoint_id` in the four api-endpoint test fixtures.

### Deferred
- Nested arrow-type authoring guidance (`Object` / `List` / `Json` markers from engine PR #52) — pending decision on the shape of that guidance (intent-only vs. pointer to schema). Not in this PR.

## Test plan

- [x] `python3 -m pytest tests/ -x -q` — 40 passed
- [ ] Manual: run `connector-builder` end-to-end on a known API connector and confirm the produced endpoint document validates against `https://schemas.analitiq.ai/api-endpoint/latest.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)